### PR TITLE
feat: Only add cloud-provider flag to API server for k8s <1.33 (#519)

### DIFF
--- a/templates/cluster-template-clusterclass.yaml
+++ b/templates/cluster-template-clusterclass.yaml
@@ -324,6 +324,18 @@ spec:
             - nutanix-quick-start-worker
     enabledIf: '{{if .project}}true{{end}}'
     name: add-project
+  - definitions:
+    - jsonPatches:
+      - op: add
+        path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/cloud-provider
+        value: external
+      selector:
+        apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+        kind: KubeadmControlPlaneTemplate
+        matchResources:
+          controlPlane: true
+    enabledIf: '{{semverCompare "< 1.33.0-0" .builtin.controlPlane.version}}'
+    name: add-apiserver-cloud-provider-external-for-pre-k8s-1.33
   variables:
   - name: sshKey
     required: true
@@ -576,7 +588,6 @@ spec:
             - 127.0.0.1
             - 0.0.0.0
             extraArgs:
-              cloud-provider: external
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
           controllerManager:
             extraArgs:

--- a/templates/clusterclass/clusterclass.yaml
+++ b/templates/clusterclass/clusterclass.yaml
@@ -340,6 +340,18 @@ spec:
             path: /spec/template/spec/project
             valueFrom:
               variable: project
+  - name: add-apiserver-cloud-provider-external-for-pre-k8s-1.33
+    enabledIf: '{{semverCompare "< 1.33.0-0" .builtin.controlPlane.version}}'
+    definitions:
+      - selector:
+          apiVersion: controlplane.cluster.x-k8s.io/v1beta1
+          kind: KubeadmControlPlaneTemplate
+          matchResources:
+            controlPlane: true
+        jsonPatches:
+          - op: add
+            path: /spec/template/spec/kubeadmConfigSpec/clusterConfiguration/apiServer/extraArgs/cloud-provider
+            value: external
   variables:
   - name: sshKey
     required: true

--- a/templates/clusterclass/kcpt.yaml
+++ b/templates/clusterclass/kcpt.yaml
@@ -13,7 +13,6 @@ spec:
               - 127.0.0.1
               - 0.0.0.0
             extraArgs:
-              cloud-provider: external
               tls-cipher-suites: TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
           controllerManager:
             extraArgs:


### PR DESCRIPTION
This flag has been removed in Kubernetes 1.33. Adding a version-dependent patch keeps backwards compatibility for the ClusterClass.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/nutanix-cloud-native/cluster-api-provider-nutanix/blob/main/CONTRIBUTING.md and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**How Has This Been Tested?**:

_Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration and test output_


**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```